### PR TITLE
fix compile issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 Debug
 build
+.vim

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.6)
 PROJECT(boost-asio-proxy)
 
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
+
 SET(Boost_USE_STATIC_LIBS OFF)
 SET(Boost_USE_MULTITHREAD ON)
 FIND_PACKAGE(Boost 1.42.0 REQUIRED COMPONENTS system thread regex)


### PR DESCRIPTION
```
git clone https://github.com/alexott/boost-asio-proxy
cd boost-asio-proxy
mkdir build
cd build
cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=yes
make
```
> [ 25%] Building CXX object CMakeFiles/proxy.dir/proxy.cpp.o
> [ 50%] Building CXX object CMakeFiles/proxy.dir/proxy-server.cpp.o
> [ 75%] Building CXX object CMakeFiles/proxy.dir/proxy-conn.cpp.o
> [100%] Linking CXX executable proxy
> /usr/bin/ld: CMakeFiles/proxy.dir/proxy-conn.cpp.o: undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
> //lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
> collect2: error: ld returned 1 exit status
> CMakeFiles/proxy.dir/build.make:149: recipe for target 'proxy' failed
> make[2]: *** [proxy] Error 1
> CMakeFiles/Makefile2:67: recipe for target 'CMakeFiles/proxy.dir/all' failed
> make[1]: *** [CMakeFiles/proxy.dir/all] Error 2
> Makefile:83: recipe for target 'all' failed
> make: *** [all] Error 2

I found a solution [here](https://stackoverflow.com/questions/34143265/undefined-reference-to-symbol-pthread-createglibc-2-2-5).

as I am a vim user, I add a line to .gitignore